### PR TITLE
Call host function

### DIFF
--- a/test.c
+++ b/test.c
@@ -4,7 +4,7 @@
 POLKAVM_IMPORT(uint32_t, get_third_number);
 
 uint32_t entry(uint32_t a, uint32_t b) {
-	return a * b;
+	return a * b + get_third_number();
 }
 
 POLKAVM_EXPORT(uint32_t, entry, uint32_t, uint32_t);


### PR DESCRIPTION
This errors but works fine without the host call: 

```pre
$ CC --target=riscv32 -march=rv32emc -mabi=ilp32e -nostdlib -nodefaultlibs -fpic -fPIE 
     -mrelax -ffast-math -gdwarf-5 -g3 -O3 -fno-exceptions -fno-rtti -Wl,--error-limit=0 
     -Wl,--emit-relocs -Wl,--no-relax test.c -o test.elf
$ polkatool link -s test.elf -o test.pvm

ERROR: failed to link "test.elf": truncated ecalli instruction
```